### PR TITLE
Reemplazo capas gesotematicos

### DIFF
--- a/ejemplos/Capas_GenericRaster.html
+++ b/ejemplos/Capas_GenericRaster.html
@@ -122,11 +122,10 @@
           center: [-467062.8225, 4683459.6216],
         });
 
-
         const olLayer = new ol.layer.Image({
           source: new ol.source.ImageWMS({
-            url: 'http://geostematicos-sigc.juntadeandalucia.es/geoserver/tematicos/wms?',
-            params: { 'LAYERS': 'tematicos:Municipios' },
+            url: 'https://www.ideandalucia.es:443/services/CDAV_01_limites_administrativos/ows?',
+            params: { 'LAYERS': 'cav_01_g13_01_TerminoMunicipal' },
           }),
           legend: 'Capa WMS'
         });

--- a/ejemplos/Capas_GenericVector.html
+++ b/ejemplos/Capas_GenericVector.html
@@ -125,7 +125,7 @@
         const olLayer = new ol.layer.Vector({
           source: new ol.source.Vector({
             format: new ol.format.GeoJSON(),
-            url: 'https://geostematicos-sigc.juntadeandalucia.es/geoserver/tematicos/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=tematicos:Provincias&maxFeatures=50&outputFormat=application%2Fjson',
+            url: 'https://www.ideandalucia.es/services/CDAV_01_limites_administrativos/wfs?service=WFS&version=1.0.0&request=GetFeature&typeName=CDAV_01_limites_administrativos:cav_01_g13_01_Provincia&maxFeatures=50&outputFormat=application%2Fjson',
             strategy: ol.loadingstrategy.bbox,
           }),
         });

--- a/ejemplos/Capas_GeoJSON.html
+++ b/ejemplos/Capas_GeoJSON.html
@@ -119,7 +119,7 @@
          
           var provincias = new IDEE.layer.GeoJSON({
               name: "Provincias", 
-              url: "http://geostematicos-sigc.juntadeandalucia.es/geoserver/tematicos/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=tematicos:Provincias&maxFeatures=50&outputFormat=application/json",
+              url: "https://www.ideandalucia.es/services/CDAV_01_limites_administrativos/wfs?service=WFS&version=1.0.0&request=GetFeature&typeName=CDAV_01_limites_administrativos:cav_01_g13_01_Provincia&maxFeatures=50&outputFormat=application%2Fjson",
               extract:false
           });
 

--- a/ejemplos/estiloCoropletas01.html
+++ b/ejemplos/estiloCoropletas01.html
@@ -119,17 +119,15 @@
                   });
 
                   let lyProv = new IDEE.layer.WFS({
-                    name: "Provincias",
-                    url: "http://geostematicos-sigc.juntadeandalucia.es/geoserver/tematicos/wfs?",
+                    name: "CDAV_01_limites_administrativos:cav_01_g13_01_Provincia",
+                    url: "https://www.ideandalucia.es/services/CDAV_01_limites_administrativos/wfs?",
                     legend: "Provincias - COROPLETAS",
-                    geometry: 'POLYGON',
+                    geometry: 'MPOLYGON',
                     extract: true,
-                  });
-
-
+        });
 
                   // se crea el estilo y se aplica a la capa
-                  let choropleth = new IDEE.style.Choropleth('u_cod_prov', ['#000000', '#008000', '#FFFFFF'], IDEE.style.quantification.JENKS(4));
+                  let choropleth = new IDEE.style.Choropleth('id', ['#000000', '#008000'], IDEE.style.quantification.JENKS(3));
                   lyProv.setStyle(choropleth);
 
                   mapjs.addLayers(lyProv);

--- a/ejemplos/estiloCoropletas02.html
+++ b/ejemplos/estiloCoropletas02.html
@@ -119,19 +119,20 @@
 
 
         });
+        
         let lyProv = new IDEE.layer.WFS({
-            name: "Provincias",
-            url: "http://geostematicos-sigc.juntadeandalucia.es/geoserver/tematicos/wfs?",
-            name: "Provincias",
-            legend: "Provincias - COROPLETAS",
-            geometry: 'POLYGON',
+                    name: "CDAV_01_limites_administrativos:cav_01_g13_01_Provincia",
+                    url: "https://www.ideandalucia.es/services/CDAV_01_limites_administrativos/wfs?",
+                    legend: "Provincias - COROPLETAS",
+                    geometry: 'MPOLYGON',
+                    extract: true,
         });
         
 
         // se crea el estilo y se aplica a la capa
         /*En caso de que queramos pasar directamente los rangos de clasificación, la función que tenemos que definir es tan simple como la siguiente:*/
         var rangos_usuario = [10, 20, 30, 40, 50];
-        let choropleth = new IDEE.style.Choropleth("u_cod_prov", ["red", "blue", "purple"], () => rangos_usuario);
+        let choropleth = new IDEE.style.Choropleth("codigo", ["red", "blue", "purple"], () => rangos_usuario);
 
 
         //se añade la capa al mapa

--- a/ejemplos/estiloGenerico01.html
+++ b/ejemplos/estiloGenerico01.html
@@ -126,14 +126,16 @@
             extract: true,
             layers: "btn0302l_rio"
         });
+        
 
         let lyProv = new IDEE.layer.WFS({
-            name: "Provincias",
-            url: "http://geostematicos-sigc.juntadeandalucia.es/geoserver/tematicos/wfs?",
-            legend: "Provincias - COROPLETAS",
-            geometry: 'POLYGON',
-            extract: true,
+                    name: "CDAV_01_limites_administrativos:cav_01_g13_01_Provincia",
+                    url: "https://www.ideandalucia.es/services/CDAV_01_limites_administrativos/wfs?",
+                    legend: "Provincias - COROPLETAS",
+                    geometry: 'MPOLYGON',
+                    extract: true,
         });
+
 
         const geodesia = new IDEE.layer.WFS({
             url: 'https://www.ign.es/wfs/redes-geodesicas?',


### PR DESCRIPTION
Se reemplazan las capas usadas en los ejemplos que estaban servidas por un servidor que ya no está operativo