### PR TITLE
Cambio en coordenadas y zoom inicial

### DIFF
--- a/ejemplos/Capas_GenericRaster.html
+++ b/ejemplos/Capas_GenericRaster.html
@@ -118,8 +118,8 @@
           container: 'mapjs', //id del contenedor del mapa
           maxZoom: 20,
           minZoom: 2,
-          zoom: 5,
-          center: [-467062.8225, 4683459.6216],
+          zoom: 7.5,
+          center: [-543959, 4502085],
         });
 
         const olLayer = new ol.layer.Image({
@@ -163,3 +163,4 @@
 </body>
 
 </html>
+


### PR DESCRIPTION
Para que la capa WMS usada de ejemplo se vea en la vista inicial